### PR TITLE
Validate Not Blocked

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -13,7 +13,7 @@ _=/usr/bin/env
 cd /home/marketface
 
 # log env to know display and other envs are set up ok
-/usr/bin/env 2>&1 | tee -a /home/marketface/marketface.log
+# /usr/bin/env 2>&1 | tee -a /home/marketface/marketface.log
 
 # run script with flock to create a lock file and run once at the time
 flock -n /var/lock/marketface.lock -c "/usr/local/bin/python /home/marketface/marketface" 2>&1 | tee -a /home/marketface/marketface.log

--- a/marketface/__main__.py
+++ b/marketface/__main__.py
@@ -9,7 +9,7 @@ from marketface import database
 from marketface.play_dynamic import page_of_items, create_item
 from marketface.scrap_marketplace import email, password
 from marketface.scrap_marketplace import get_browser_context
-from marketface.page.facebook import FacebookPage, LoginCredentials
+from marketface.page.facebook import FacebookPage, LoginCredentials, PageBlocked
 from marketface.logger import getLogger
 
 
@@ -17,6 +17,7 @@ logger = getLogger("marketface.__main__")
 
 
 def main() -> None:
+    exit_with_error = False
     queries: List[str] = [
         # build search url for moto honda wave
         "moto honda",
@@ -90,9 +91,11 @@ def main() -> None:
             try:
                 # TODO scroll down to get all items in search page
                 # page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
-                facebook.market_search(
+                market_page = facebook.market_search(
                     query=query
                 )
+                if not market_page.valid_page:
+                    logger.error("invalid page '%s'", query)
                 for href in facebook.get_market_href():
                     try:
                         model = create_item(href)
@@ -104,9 +107,16 @@ def main() -> None:
                 # collect_articles_all(page)
                 # 4. pull the data from each of the new articles links
                 # pull_articles(page, context)
+            except PageBlocked as err:
+                logger.error(err)
+                exit_with_error = True
+                break
             except Exception as err:
                 logger.error("item search error on search '%s': %s", query, err)
-        logger.info("main completed successfully")
+        if exit_with_error:
+            logger.info("main completed with an error")
+        else:
+            logger.info("main completed successfully")
 
 if __name__ == "__main__":
     main()

--- a/marketface/__main__.py
+++ b/marketface/__main__.py
@@ -95,7 +95,7 @@ def main() -> None:
                     query=query
                 )
                 if not market_page.valid_page:
-                    logger.error("invalid page '%s'", query)
+                    logger.warning("invalid page '%s'", query)
                 for href in facebook.get_market_href():
                     try:
                         model = create_item(href)
@@ -114,7 +114,7 @@ def main() -> None:
             except Exception as err:
                 logger.error("item search error on search '%s': %s", query, err)
         if exit_with_error:
-            logger.info("main completed with an error")
+            logger.error("main completed with an error")
         else:
             logger.info("main completed successfully")
 

--- a/marketface/page/facebook.py
+++ b/marketface/page/facebook.py
@@ -32,12 +32,22 @@ xdescs = [
     f"xpath={xbase}/div[5]",
     f"xpath={xbase}/div[5]/div[2]/div/div[1]",
 ]
+# To check if the session / account is blocked
+xblocked = "xpath=/html/body/div[1]/div/div[1]/div/div[3]/div/div/div[1]/div[1]/div/div"
 
 
 @dataclass
 class LoginCredentials:
     username: str
     password: str
+
+
+class PageInvalid(Exception):
+    pass
+
+
+class PageBlocked(PageInvalid):
+    pass
 
 
 class ItemDetails:
@@ -130,7 +140,7 @@ class WebPage:
         self.pages: Dict[str, Page] = {}
         self.current_page: Optional[Page] = None
         self.logger = getLogger("marketface.pages.facebook.WebPage")
-        self.invalid_page = True
+        self.valid_page = True
 
     def set_current_page(self, page_name:str, page: Page) -> None:
         self.current_page = page
@@ -178,6 +188,18 @@ class WebPage:
         count = locator.count()
         for i in range(count):
             yield locator.nth(i)
+        if count <= 0:
+            self.raise_if_blocked(page)
+
+    def is_blocked(self, page: Page) -> bool:
+        blocked_content = page.locator(xblocked).text_content()
+        if blocked_content and "You’re Temporarily Blocked" in blocked_content:
+            return True
+        return False
+
+    def raise_if_blocked(self, page: Page) -> None:
+        if self.is_blocked(page):
+            raise PageBlocked("the session / account is blocked")
 
 
 class MarketplacePage(WebPage):
@@ -257,8 +279,7 @@ class FacebookPage(WebPage):
         return self
 
     def market_search_validate(self, page: Page) -> bool:
-        # TODO
-        is_valid = True
+        is_valid = not self.is_blocked(page)
         return is_valid
 
     def market_search(
@@ -281,7 +302,7 @@ class FacebookPage(WebPage):
             f"{self.host}/marketplace/{self.location}/search?{encoded_params}"
         )
         # validate if blocked or any other unusual pages
-        self.invalid_page = self.market_search_validate(page)
+        self.valid_page = self.market_search_validate(page)
         return self
 
     def get_market_id(
@@ -313,7 +334,6 @@ class FacebookPage(WebPage):
 
     def get_market_links(
             self,
-            xpath: str = "//a",
             page: Optional[Page] = None,
         ) -> Iterator[Locator]:
         for link in self.get_links(page=page):
@@ -325,13 +345,17 @@ class FacebookPage(WebPage):
     def get_market_href(
             self,
         ) -> Iterator[str]:
+        links_found = False
         for link in self.get_market_links():
             href = link.get_attribute("href") or ""
             if href.startswith("/marketplace/item/"):
                 market_id = self.get_market_id(url=href)
+                links_found = True
                 yield f"{self.host}/marketplace/item/{market_id}"
             else:
                 raise NotImplementedError("get_market_id only supports relative urls starting with /marketplace/item/")
+        if not links_found and self.current_page:
+            self.raise_if_blocked(self.current_page)
 
     def market_item(
             self,

--- a/marketface/page/facebook.py
+++ b/marketface/page/facebook.py
@@ -193,9 +193,9 @@ class WebPage:
 
     def is_blocked(self, page: Page) -> bool:
         blocked_content = page.locator(xblocked).text_content()
-        if blocked_content and "You’re Temporarily Blocked" in blocked_content:
-            return True
-        return False
+        return bool(
+            blocked_content and "You’re Temporarily Blocked" in blocked_content
+        )
 
     def raise_if_blocked(self, page: Page) -> None:
         if self.is_blocked(page):
@@ -279,8 +279,7 @@ class FacebookPage(WebPage):
         return self
 
     def market_search_validate(self, page: Page) -> bool:
-        is_valid = not self.is_blocked(page)
-        return is_valid
+        return not self.is_blocked(page)
 
     def market_search(
             self,

--- a/marketface/page/facebook.py
+++ b/marketface/page/facebook.py
@@ -130,6 +130,7 @@ class WebPage:
         self.pages: Dict[str, Page] = {}
         self.current_page: Optional[Page] = None
         self.logger = getLogger("marketface.pages.facebook.WebPage")
+        self.invalid_page = True
 
     def set_current_page(self, page_name:str, page: Page) -> None:
         self.current_page = page
@@ -255,6 +256,11 @@ class FacebookPage(WebPage):
             self.logger.error(err)
         return self
 
+    def market_search_validate(self, page: Page) -> bool:
+        # TODO
+        is_valid = True
+        return is_valid
+
     def market_search(
             self,
             query: str,
@@ -274,6 +280,8 @@ class FacebookPage(WebPage):
         page.goto(
             f"{self.host}/marketplace/{self.location}/search?{encoded_params}"
         )
+        # validate if blocked or any other unusual pages
+        self.invalid_page = self.market_search_validate(page)
         return self
 
     def get_market_id(


### PR DESCRIPTION
## Summary by Sourcery

Add detection and handling of blocked Facebook marketplace sessions, integrate validation into search and link retrieval flows with appropriate exception raising, adjust main to abort on block and report status, and disable redundant env logging in cron.

New Features:
- Detect blocked Facebook marketplace sessions by introducing xblocked locator, PageInvalid/PageBlocked exceptions, and is_blocked/raise_if_blocked methods.

Enhancements:
- Validate pages during market_search, get_links, and get_market_href to set a valid_page flag and raise on blocked sessions.
- Update main to handle PageBlocked, track exit status, and log completion state accordingly.

Chores:
- Comment out environment logging in cron.sh.